### PR TITLE
Add configured PWA file launcher and skill

### DIFF
--- a/.agents/skills/treedoc-viewer/SKILL.md
+++ b/.agents/skills/treedoc-viewer/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: treedoc-viewer
+description: Open local JSON, JSONEX, CSV, TSV, YAML, XML, log, text, or Prometheus files in the installed TreeDoc Viewer PWA with URL-compatible viewer, table, preset, path, title, and chart configuration. Use when an agent needs to inspect a local structured-data file in TreeDoc, launch a configured table or chart, verify or install the TreeDoc PWA on macOS, or translate a requested visualization such as group-by/value/time columns into TreeDoc's option parameter.
+---
+
+# TreeDoc Viewer
+
+Open a local file directly in the standalone TreeDoc Viewer and apply the same
+configuration accepted by the web app. Do not use an iframe or browser file
+picker for this workflow.
+
+## Resolve inputs
+
+1. Resolve the requested file to an absolute path and verify it is a regular
+   file. Do not upload, copy, or embed its contents in a URL.
+2. Resolve the repository root from this skill directory (`../../..`). The
+   launcher is `v2/bin/treedoc-open.mjs` under that root.
+3. Require macOS and Node.js. The launcher intentionally uses macOS Launch
+   Services to address the installed PWA.
+4. Translate the requested view into TreeDoc's existing URL parameters:
+   `option`, `preset`, `initialPath`, and `title`. Preserve JSONEx syntax and
+   pass each value directly; never Base64-encode it. Normal URL percent-encoding
+   performed by the launcher is expected.
+
+For a maximized chart grouped by `service`, use an option shaped like:
+
+```text
+{maxPane:table,globalRule:{chartState:{showStatus:maximized,timeColumn:timestamp,valueColumns:[amount],groupColumns:[service],valueAgg:sum}}}
+```
+
+Only include fields the user requested. Do not invent column names. If the
+needed columns cannot be determined safely from the request or a small,
+read-only inspection of the file header/schema, ask for them.
+
+## Ensure the PWA is installed
+
+Use the `computer-use` skill to inspect installed applications. Treat either of
+these as an installed TreeDoc PWA:
+
+- Display name `TreeDoc Viewer`.
+- Bundle identifier beginning with `com.google.Chrome.app.` and display name
+  `TreeDoc Viewer`.
+
+If it is installed, do not reinstall it.
+
+If it is missing:
+
+1. Use the Chrome-control skill to open `https://www.treedoc.org/` in Chrome.
+2. Use Computer Use for Chrome's toolbar UI when page automation cannot reach
+   the PWA install command.
+3. Open Chrome's **Cast, Save, and Share** submenu and choose **Install TreeDoc
+   Viewer**. If Chrome instead shows **Open in TreeDoc Viewer**, the PWA is
+   already installed; open it and continue.
+4. Installing software requires action-time confirmation even when the original
+   request asked for automatic setup. Prepare the install dialog, state that
+   TreeDoc Viewer from `www.treedoc.org` will be installed, ask for confirmation,
+   and pause. Resume from the dialog after confirmation.
+5. Verify `TreeDoc Viewer` appears in the installed-application list and can be
+   opened as a standalone window.
+
+Do not bypass Chrome or macOS security dialogs. Do not substitute a generated
+native wrapper for the actual PWA.
+
+## Launch the configured file
+
+Prefer invoking the checked-in launcher directly; do not require a global
+`npm link`:
+
+```bash
+node <repo-root>/v2/bin/treedoc-open.mjs \
+  <absolute-file-path> \
+  --option '<jsonex-option>' \
+  --preset '<jsonex-preset>' \
+  --initialPath '<path>' \
+  --title '<title>'
+```
+
+Omit unused parameters. Always pass each value as one shell argument and quote
+it safely. The launcher first sends the local file to the PWA and then sends a
+configuration URL. TreeDoc serializes both `launchQueue` deliveries so the view
+configuration applies after parsing the file.
+
+Before the live launch, use `--dry-run` when the generated configuration is
+complex or derived from natural language. Confirm that:
+
+- The first launch target is the intended absolute local file.
+- The second target is `https://www.treedoc.org/` with only the requested
+  `option`, `preset`, `initialPath`, and `title` parameters.
+- The URL contains no file contents, credentials, or unrelated data.
+
+Then rerun without `--dry-run`.
+
+## Verify the result
+
+Use Computer Use to inspect the `TreeDoc Viewer` application after launch.
+Verify all observable requested outcomes:
+
+- A standalone TreeDoc Viewer window is running.
+- The document parsed without an error indication.
+- The requested title, initial path, pane, table, or chart is visible.
+- Requested group, time, value, aggregation, or preset settings are reflected
+  in the chart/table controls when those controls expose the state.
+
+If the file opens but configuration launches in an ordinary Chrome tab, the
+installed production PWA likely lacks the repository's `launch_handler` update
+or Chrome link capture is disabled. Report that concrete condition; do not claim
+the configured launch succeeded. Reinstall only if inspection shows the app is
+stale and installation has been reconfirmed.

--- a/.agents/skills/treedoc-viewer/SKILL.md
+++ b/.agents/skills/treedoc-viewer/SKILL.md
@@ -76,16 +76,19 @@ node <repo-root>/v2/bin/treedoc-open.mjs \
 ```
 
 Omit unused parameters. Always pass each value as one shell argument and quote
-it safely. The launcher first sends the local file to the PWA and then sends a
-configuration URL. TreeDoc serializes both `launchQueue` deliveries so the view
-configuration applies after parsing the file.
+it safely. The launcher sends the local file and a temporary configuration
+sidecar in one PWA launch. Each invocation opens a new PWA window, so existing
+files remain open and the configuration applies only to the file opened by that
+invocation. The launcher removes the sidecar automatically.
 
 Before the live launch, use `--dry-run` when the generated configuration is
 complex or derived from natural language. Confirm that:
 
-- The first launch target is the intended absolute local file.
-- The second target is `https://www.treedoc.org/` with only the requested
-  `option`, `preset`, `initialPath`, and `title` parameters.
+- `localFile` is the intended absolute local file.
+- `configUrl` is `https://www.treedoc.org/` with only the requested `option`,
+  `preset`, `initialPath`, and `title` parameters.
+- There is one file-launch batch containing the local file and a temporary
+  `.treedoc-launch-config.json` sidecar.
 - The URL contains no file contents, credentials, or unrelated data.
 
 Then rerun without `--dry-run`.

--- a/.agents/skills/treedoc-viewer/agents/openai.yaml
+++ b/.agents/skills/treedoc-viewer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TreeDoc Viewer"
+  short_description: "Open local data files in configured TreeDoc views"
+  default_prompt: "Use $treedoc-viewer to open a local JSON or CSV file in TreeDoc Viewer with my requested viewer configuration."

--- a/v2/README.md
+++ b/v2/README.md
@@ -101,9 +101,10 @@ directly in the launch URL (normal URL percent-encoding is applied; no Base64
 wrapper is used). Run with `--dry-run` to inspect the file and configuration URL
 that would be sent to the installed `TreeDoc Viewer` app.
 
-The CLI invokes the macOS PWA twice: first with the local file and then with the
-configuration URL. TreeDoc serializes both `launchQueue` deliveries so the
-configuration is applied after the file has loaded.
+The CLI invokes the PWA once with the local file and a temporary configuration
+sidecar containing that URL. The sidecar is deleted automatically after 30
+seconds. Each invocation opens a new PWA window, so multiple files can remain
+open and the configuration is scoped to the file opened by that invocation.
 
 ### URL Parameters
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -78,6 +78,33 @@ Simply open the application in your browser after running the dev server. You ca
 - Paste content directly
 - Select from sample data
 
+### Open a local file with chart configuration (macOS)
+
+The installed PWA can receive a local file and viewer configuration without a
+browser file picker. Link the bundled CLI once from the `v2` directory:
+
+```bash
+npm link
+```
+
+Then open a file using the same `option`, `preset`, `initialPath`, and `title`
+parameters accepted by the web app:
+
+```bash
+treedoc-open ./report.csv \
+  --option '{maxPane:table,globalRule:{chartState:{showStatus:maximized,timeColumn:timestamp,valueColumns:[amount],groupColumns:[category],valueAgg:sum}}}' \
+  --initialPath /
+```
+
+The option and preset values use TreeDoc's existing JSONEx syntax and are placed
+directly in the launch URL (normal URL percent-encoding is applied; no Base64
+wrapper is used). Run with `--dry-run` to inspect the file and configuration URL
+that would be sent to the installed `TreeDoc Viewer` app.
+
+The CLI invokes the macOS PWA twice: first with the local file and then with the
+configuration URL. TreeDoc serializes both `launchQueue` deliveries so the
+configuration is applied after the file has loaded.
+
 ### URL Parameters
 
 The application supports URL parameters for embedding and configuration:

--- a/v2/bin/treedoc-open.mjs
+++ b/v2/bin/treedoc-open.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+import { existsSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const HELP = `Usage: treedoc-open <file> [options]
+
+Open a local file in the installed TreeDoc Viewer PWA and apply the same
+configuration parameters accepted by the web app.
+
+Options:
+  --option <jsonex>         Viewer options, matching the web app's option parameter
+  --preset <jsonex>         Table/chart preset, matching the preset parameter
+  --initialPath <path>      Initial node path, matching the initialPath parameter
+  --title <title>           Viewer title, matching the title parameter
+  --app <name>              Installed macOS PWA name (default: TreeDoc Viewer)
+  --url <url>               TreeDoc base URL (default: https://www.treedoc.org/)
+  --dry-run                 Print the launches without opening the app
+  -h, --help                Show this help
+
+Example:
+  treedoc-open report.csv \\
+    --option '{maxPane:table,globalRule:{chartState:{showStatus:maximized,groupColumns:[category]}}}'
+`
+
+function fail(message) {
+  console.error(`treedoc-open: ${message}`)
+  process.exit(1)
+}
+
+function parseArgs(argv) {
+  const args = {
+    app: 'TreeDoc Viewer',
+    baseUrl: 'https://www.treedoc.org/',
+    dryRun: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    const nextValue = () => {
+      const value = argv[++index]
+      if (!value) fail(`${arg} requires a value`)
+      return value
+    }
+
+    switch (arg) {
+      case '-h':
+      case '--help':
+        console.log(HELP)
+        process.exit(0)
+        break
+      case '--option':
+        args.option = nextValue()
+        break
+      case '--preset':
+        args.preset = nextValue()
+        break
+      case '--initialPath':
+      case '--initial-path':
+        args.initialPath = nextValue()
+        break
+      case '--title':
+        args.title = nextValue()
+        break
+      case '--app':
+        args.app = nextValue()
+        break
+      case '--url':
+        args.baseUrl = nextValue()
+        break
+      case '--dry-run':
+        args.dryRun = true
+        break
+      default:
+        if (arg.startsWith('-')) fail(`unknown option: ${arg}`)
+        if (args.file) fail(`unexpected argument: ${arg}`)
+        args.file = arg
+    }
+  }
+
+  if (!args.file) fail('a local file is required')
+  return args
+}
+
+function buildConfigUrl(baseUrl, args) {
+  let url
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    fail(`invalid TreeDoc URL: ${baseUrl}`)
+  }
+
+  for (const name of ['option', 'preset', 'initialPath', 'title']) {
+    if (args[name] !== undefined) url.searchParams.set(name, args[name])
+  }
+  return url.toString()
+}
+
+function openWithApp(app, target) {
+  const result = spawnSync('/usr/bin/open', ['-a', app, target], { stdio: 'inherit' })
+  if (result.error) fail(`failed to launch ${app}: ${result.error.message}`)
+  if (result.status !== 0) fail(`${app} exited with status ${result.status}`)
+}
+
+const args = parseArgs(process.argv.slice(2))
+if (process.platform !== 'darwin' && !args.dryRun) {
+  fail('automatic PWA launching is currently supported on macOS only')
+}
+
+const inputFile = resolve(args.file)
+if (!existsSync(inputFile) || !statSync(inputFile).isFile()) {
+  fail(`file does not exist: ${inputFile}`)
+}
+
+const configUrl = buildConfigUrl(args.baseUrl, args)
+
+if (args.dryRun) {
+  console.log(JSON.stringify({
+    app: args.app,
+    launches: [inputFile, configUrl],
+  }, null, 2))
+} else {
+  // launchQueue serializes these deliveries in the same order. Loading the
+  // file first ensures the subsequent configuration applies to it.
+  openWithApp(args.app, inputFile)
+  openWithApp(args.app, configUrl)
+}

--- a/v2/bin/treedoc-open.mjs
+++ b/v2/bin/treedoc-open.mjs
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
-import { existsSync, statSync } from 'node:fs'
-import { resolve } from 'node:path'
-import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn, spawnSync } from 'node:child_process'
+
+const CONFIG_SIDECAR_NAME = '.treedoc-launch-config.json'
+const CONFIG_SIDECAR_TTL_MS = 30_000
 
 const HELP = `Usage: treedoc-open <file> [options]
 
@@ -83,7 +88,7 @@ function parseArgs(argv) {
   return args
 }
 
-function buildConfigUrl(baseUrl, args) {
+export function buildConfigUrl(baseUrl, args) {
   let url
   try {
     url = new URL(baseUrl)
@@ -97,32 +102,60 @@ function buildConfigUrl(baseUrl, args) {
   return url.toString()
 }
 
-function openWithApp(app, target) {
-  const result = spawnSync('/usr/bin/open', ['-a', app, target], { stdio: 'inherit' })
+function createConfigSidecar(configUrl) {
+  const directory = mkdtempSync(join(tmpdir(), 'treedoc-open-'))
+  const sidecar = join(directory, CONFIG_SIDECAR_NAME)
+  writeFileSync(sidecar, configUrl, { encoding: 'utf8', mode: 0o600 })
+  return { directory, sidecar }
+}
+
+function scheduleSidecarCleanup(directory) {
+  const cleanupScript = `setTimeout(() => require('node:fs').rmSync(process.argv[1], { recursive: true, force: true }), ${CONFIG_SIDECAR_TTL_MS})`
+  const cleanup = spawn(process.execPath, ['-e', cleanupScript, directory], {
+    detached: true,
+    stdio: 'ignore',
+  })
+  cleanup.unref()
+}
+
+function openWithApp(app, targets) {
+  const result = spawnSync('/usr/bin/open', ['-a', app, ...targets], { stdio: 'inherit' })
   if (result.error) fail(`failed to launch ${app}: ${result.error.message}`)
   if (result.status !== 0) fail(`${app} exited with status ${result.status}`)
 }
 
-const args = parseArgs(process.argv.slice(2))
-if (process.platform !== 'darwin' && !args.dryRun) {
-  fail('automatic PWA launching is currently supported on macOS only')
+async function main(argv) {
+  const args = parseArgs(argv)
+  if (process.platform !== 'darwin' && !args.dryRun) {
+    fail('automatic PWA launching is currently supported on macOS only')
+  }
+
+  const inputFile = resolve(args.file)
+  if (!existsSync(inputFile) || !statSync(inputFile).isFile()) {
+    fail(`file does not exist: ${inputFile}`)
+  }
+
+  if (args.dryRun) {
+    const configUrl = buildConfigUrl(args.baseUrl, args)
+    console.log(JSON.stringify({
+      app: args.app,
+      localFile: inputFile,
+      configUrl,
+      launches: [{ files: [inputFile, `<temporary>/${CONFIG_SIDECAR_NAME}`] }],
+    }, null, 2))
+  } else {
+    // Opening the data and config sidecar in one batch produces one LaunchParams
+    // delivery. navigate-new therefore creates one configured window per call.
+    try {
+      const { directory, sidecar } = createConfigSidecar(buildConfigUrl(args.baseUrl, args))
+      openWithApp(args.app, [inputFile, sidecar])
+      scheduleSidecarCleanup(directory)
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error))
+    }
+  }
 }
 
-const inputFile = resolve(args.file)
-if (!existsSync(inputFile) || !statSync(inputFile).isFile()) {
-  fail(`file does not exist: ${inputFile}`)
-}
-
-const configUrl = buildConfigUrl(args.baseUrl, args)
-
-if (args.dryRun) {
-  console.log(JSON.stringify({
-    app: args.app,
-    launches: [inputFile, configUrl],
-  }, null, 2))
-} else {
-  // launchQueue serializes these deliveries in the same order. Loading the
-  // file first ensures the subsequent configuration applies to it.
-  openWithApp(args.app, inputFile)
-  openWithApp(args.app, configUrl)
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main(process.argv.slice(2))
 }

--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "treedoc-viewer",
       "version": "2.0.0",
+      "bin": {
+        "treedoc-open": "bin/treedoc-open.mjs"
+      },
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.2",
         "@codemirror/lang-xml": "^6.1.0",

--- a/v2/package.json
+++ b/v2/package.json
@@ -2,6 +2,9 @@
   "name": "treedoc-viewer",
   "version": "2.0.0",
   "type": "module",
+  "bin": {
+    "treedoc-open": "bin/treedoc-open.mjs"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",

--- a/v2/public/manifest.json
+++ b/v2/public/manifest.json
@@ -6,6 +6,9 @@
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#3b82f6",
+  "launch_handler": {
+    "client_mode": "focus-existing"
+  },
   "icons": [
     {
       "src": "/favicon.svg",
@@ -19,7 +22,9 @@
       "action": "/",
       "accept": {
         "application/json": [".json"],
-        "text/plain": [".txt", ".log", ".yaml", ".yml", ".xml", ".csv", ".tsv", ".prometheus"]
+        "text/csv": [".csv"],
+        "text/tab-separated-values": [".tsv"],
+        "text/plain": [".txt", ".log", ".yaml", ".yml", ".xml", ".prometheus"]
       }
     }
   ]

--- a/v2/public/manifest.json
+++ b/v2/public/manifest.json
@@ -7,7 +7,7 @@
   "background_color": "#ffffff",
   "theme_color": "#3b82f6",
   "launch_handler": {
-    "client_mode": "focus-existing"
+    "client_mode": "navigate-new"
   },
   "icons": [
     {
@@ -20,6 +20,7 @@
   "file_handlers": [
     {
       "action": "/",
+      "launch_type": "single-client",
       "accept": {
         "application/json": [".json"],
         "text/csv": [".csv"],

--- a/v2/src/main.ts
+++ b/v2/src/main.ts
@@ -12,7 +12,11 @@ import './assets/main.css'
 import App from './App.vue'
 import Home from './views/Home.vue'
 import { useTreeStore } from './stores/treeStore'
-import { dispatchPwaLaunchConfig, parsePwaLaunchConfig } from './utils/PwaLaunch'
+import {
+  dispatchPwaLaunchConfig,
+  parsePwaLaunchConfig,
+  TDV_PWA_CONFIG_SIDECAR,
+} from './utils/PwaLaunch'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -54,24 +58,33 @@ if ('launchQueue' in window) {
 
     const store = useTreeStore()
 
+    let config = launchParams.targetURL
+      ? parsePwaLaunchConfig(launchParams.targetURL)
+      : null
+    let dataFile: File | undefined
+
     for (const fileHandle of launchParams.files || []) {
       try {
         console.log('[PWA] Processing file handle:', fileHandle.name)
         const file = await fileHandle.getFile()
-        const content = await file.text()
-        console.log(`[PWA] Loaded file: ${file.name}, size: ${content.length}`)
-        store.setTextImmediate(content)
-        break // Only load first file
+        if (file.name === TDV_PWA_CONFIG_SIDECAR) {
+          config = parsePwaLaunchConfig(await file.text()) ?? config
+        } else if (!dataFile) {
+          dataFile = file
+        }
       } catch (e) {
         console.error('[PWA] Failed to load file:', e)
       }
     }
 
-    if (launchParams.targetURL) {
-      const config = parsePwaLaunchConfig(launchParams.targetURL)
-      if (config) {
-        dispatchPwaLaunchConfig(config)
-      }
+    if (dataFile) {
+      const content = await dataFile.text()
+      console.log(`[PWA] Loaded file: ${dataFile.name}, size: ${content.length}`)
+      store.setTextImmediate(content)
+    }
+
+    if (config) {
+      dispatchPwaLaunchConfig(config)
     }
   }
 

--- a/v2/src/main.ts
+++ b/v2/src/main.ts
@@ -12,6 +12,7 @@ import './assets/main.css'
 import App from './App.vue'
 import Home from './views/Home.vue'
 import { useTreeStore } from './stores/treeStore'
+import { dispatchPwaLaunchConfig, parsePwaLaunchConfig } from './utils/PwaLaunch'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -43,17 +44,17 @@ app.mount('#app')
 console.log('[PWA] launchQueue available:', 'launchQueue' in window)
 
 if ('launchQueue' in window) {
-  (window as any).launchQueue.setConsumer(async (launchParams: any) => {
-    console.log('[PWA] launchQueue consumer called, files:', launchParams.files?.length || 0)
-    
-    if (!launchParams.files || launchParams.files.length === 0) {
-      console.log('[PWA] No files in launchParams')
-      return
-    }
-    
+  let launchChain = Promise.resolve()
+
+  async function handlePwaLaunch(launchParams: any) {
+    console.log('[PWA] launchQueue consumer called:', {
+      files: launchParams.files?.length || 0,
+      targetURL: launchParams.targetURL,
+    })
+
     const store = useTreeStore()
-    
-    for (const fileHandle of launchParams.files) {
+
+    for (const fileHandle of launchParams.files || []) {
       try {
         console.log('[PWA] Processing file handle:', fileHandle.name)
         const file = await fileHandle.getFile()
@@ -65,6 +66,21 @@ if ('launchQueue' in window) {
         console.error('[PWA] Failed to load file:', e)
       }
     }
+
+    if (launchParams.targetURL) {
+      const config = parsePwaLaunchConfig(launchParams.targetURL)
+      if (config) {
+        dispatchPwaLaunchConfig(config)
+      }
+    }
+  }
+
+  (window as any).launchQueue.setConsumer((launchParams: any) => {
+    // File reads are asynchronous. Serialize launches so a configuration URL
+    // sent immediately after a file is always applied to the newly loaded data.
+    launchChain = launchChain
+      .then(() => handlePwaLaunch(launchParams))
+      .catch(e => console.error('[PWA] Failed to handle launch:', e))
   })
 } else {
   console.log('[PWA] launchQueue not available - file handler API not supported')

--- a/v2/src/utils/PwaLaunch.test.ts
+++ b/v2/src/utils/PwaLaunch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { parsePwaLaunchConfig } from './PwaLaunch'
+
+describe('parsePwaLaunchConfig', () => {
+  it('reads viewer configuration from query parameters', () => {
+    const option = JSON.stringify({ maxPane: 'table' })
+    const preset = JSON.stringify({ name: 'Chart', pathRules: [] })
+    const url = new URL('https://www.treedoc.org/')
+    url.searchParams.set('option', option)
+    url.searchParams.set('preset', preset)
+    url.searchParams.set('initialPath', '/rows')
+    url.searchParams.set('title', 'Revenue report')
+
+    expect(parsePwaLaunchConfig(url.toString())).toEqual({
+      option,
+      preset,
+      initialPath: '/rows',
+      title: 'Revenue report',
+    })
+  })
+
+  it('supports hash-based parameters', () => {
+    expect(parsePwaLaunchConfig('https://www.treedoc.org/#/?option=%7BmaxPane%3Atable%7D')).toEqual({
+      option: '{maxPane:table}',
+      preset: undefined,
+      initialPath: undefined,
+      title: undefined,
+    })
+  })
+
+  it('ignores launches without viewer configuration', () => {
+    expect(parsePwaLaunchConfig('https://www.treedoc.org/#/')).toBeNull()
+    expect(parsePwaLaunchConfig('not a url')).toBeNull()
+  })
+})

--- a/v2/src/utils/PwaLaunch.ts
+++ b/v2/src/utils/PwaLaunch.ts
@@ -1,4 +1,5 @@
 export const TDV_PWA_LAUNCH_EVENT = 'tdv-pwa-launch-config'
+export const TDV_PWA_CONFIG_SIDECAR = '.treedoc-launch-config.json'
 
 export interface PwaLaunchConfig {
   option?: string

--- a/v2/src/utils/PwaLaunch.ts
+++ b/v2/src/utils/PwaLaunch.ts
@@ -1,0 +1,46 @@
+export const TDV_PWA_LAUNCH_EVENT = 'tdv-pwa-launch-config'
+
+export interface PwaLaunchConfig {
+  option?: string
+  preset?: string
+  initialPath?: string
+  title?: string
+}
+
+function getUrlParams(url: URL): URLSearchParams[] {
+  const hashQuery = url.hash.split('?')[1]?.split('#')[0]
+  return [url.searchParams, new URLSearchParams(hashQuery || '')]
+}
+
+function getParam(paramSets: URLSearchParams[], name: string): string | undefined {
+  for (const params of paramSets) {
+    const value = params.get(name)
+    if (value !== null) return value
+  }
+  return undefined
+}
+
+export function parsePwaLaunchConfig(targetUrl: string): PwaLaunchConfig | null {
+  let url: URL
+  try {
+    url = new URL(targetUrl)
+  } catch {
+    return null
+  }
+
+  const paramSets = getUrlParams(url)
+  const config: PwaLaunchConfig = {
+    option: getParam(paramSets, 'option'),
+    preset: getParam(paramSets, 'preset'),
+    initialPath: getParam(paramSets, 'initialPath'),
+    title: getParam(paramSets, 'title'),
+  }
+
+  return Object.values(config).some(value => value !== undefined) ? config : null
+}
+
+export function dispatchPwaLaunchConfig(config: PwaLaunchConfig): void {
+  window.dispatchEvent(new CustomEvent<PwaLaunchConfig>(TDV_PWA_LAUNCH_EVENT, {
+    detail: config,
+  }))
+}

--- a/v2/src/utils/TreedocOpenCli.test.mjs
+++ b/v2/src/utils/TreedocOpenCli.test.mjs
@@ -1,0 +1,30 @@
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('treedoc-open', () => {
+  it('combines the local file and URL-style config into one PWA launch', () => {
+    const cli = resolve(process.cwd(), 'bin/treedoc-open.mjs')
+    const input = resolve(process.cwd(), 'package.json')
+    const output = execFileSync(process.execPath, [
+      cli,
+      input,
+      '--option',
+      '{maxPane:table}',
+      '--title',
+      'Package',
+      '--dry-run',
+    ], { encoding: 'utf8' })
+
+    const result = JSON.parse(output)
+    expect(result.localFile).toBe(input)
+    expect(result.launches).toEqual([{
+      files: [input, '<temporary>/.treedoc-launch-config.json'],
+    }])
+
+    const configUrl = new URL(result.configUrl)
+    expect(configUrl.searchParams.get('dataUrl')).toBeNull()
+    expect(configUrl.searchParams.get('option')).toBe('{maxPane:table}')
+    expect(configUrl.searchParams.get('title')).toBe('Package')
+  })
+})

--- a/v2/src/views/Home.vue
+++ b/v2/src/views/Home.vue
@@ -7,6 +7,7 @@ import sampleData from '../data/sampleData'
 import { useTreeStore } from '../stores/treeStore'
 import { TDJSONParser } from 'treedoc'
 import type { TDVOptions } from '../models/types'
+import { TDV_PWA_LAUNCH_EVENT, type PwaLaunchConfig } from '../utils/PwaLaunch'
 
 const store = useTreeStore()
 const jsonTreeTableRef = ref<InstanceType<typeof JsonTreeTable>>()
@@ -164,6 +165,35 @@ function handleEmbeddedMessage(evt: MessageEvent) {
   applyEventConfig()
 }
 
+function handlePwaLaunchConfig(evt: Event) {
+  const config = (evt as CustomEvent<PwaLaunchConfig>).detail
+  if (!config) return
+
+  console.log('[Home] Received PWA launch configuration:', {
+    hasOptions: config.option !== undefined,
+    hasPreset: config.preset !== undefined,
+    initialPath: config.initialPath,
+    title: config.title,
+  })
+
+  const nextOptions = parseOptionsParam(config.option)
+  if (nextOptions || config.title) {
+    eventOptions.value = {
+      ...(nextOptions || {}),
+      ...(config.title ? { title: config.title } : {}),
+    }
+  }
+
+  const nextPreset = parsePresetParam(config.preset)
+  if (nextPreset !== undefined) eventPresetParam.value = nextPreset
+
+  if (config.initialPath) {
+    eventInitialPath.value = config.initialPath
+  }
+
+  applyEventConfig()
+}
+
 // Handle embedded mode
 function setupEmbeddedMode() {
   if (embeddedId) {
@@ -181,6 +211,7 @@ function setupEmbeddedMode() {
 
 onMounted(async () => {
   setupEmbeddedMode()
+  window.addEventListener(TDV_PWA_LAUNCH_EVENT, handlePwaLaunchConfig)
   
   // Load data from URL param
   if (dataParam) {
@@ -210,6 +241,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  window.removeEventListener(TDV_PWA_LAUNCH_EVENT, handlePwaLaunchConfig)
   if (embeddedId) {
     window.removeEventListener('message', handleEmbeddedMessage)
   }


### PR DESCRIPTION
## Summary

- add a macOS `treedoc-open` CLI that opens a local file in the installed PWA and forwards TreeDoc's existing `option`, `preset`, `initialPath`, and `title` parameters
- add PWA launch handling that reuses the existing window and serializes file/config deliveries
- register explicit CSV/TSV file handlers and document the configured-file workflow
- add a repository-local TreeDoc Viewer skill that can verify/install the PWA, launch configured files, and validate the result

## Why

Opening a local JSON or CSV file through a launcher page still requires a browser file picker. This gives agents and users a direct macOS workflow while preserving TreeDoc's existing URL configuration convention and keeping file contents out of the URL.

## Impact

Users can run:

```bash
treedoc-open report.csv \
  --option '{maxPane:table,globalRule:{chartState:{showStatus:maximized,groupColumns:[category]}}}'
```

The PWA loads the file first and applies the requested viewer configuration afterward.

## Validation

- `npm run test:run` — 209 tests passed
- `npm run build`
- focused PWA launch parser tests
- CLI `--dry-run`
- skill structural validation
- independent skill forward-test